### PR TITLE
chore: update renovate to label and to do automerging

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 jobs:
   build:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "semanticCommits": "enabled",
+  "labels": [
+    "renovate"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
I added labels and auto-merge to the renovate configuration.

If this configuration works, we can extend it as a basis for all our other repos.

We also need to follow: https://docs.renovatebot.com/key-concepts/automerge/#if-you-use-github-actions

